### PR TITLE
Simplify retrieval of commit id

### DIFF
--- a/src/config-package.inc.sh
+++ b/src/config-package.inc.sh
@@ -60,7 +60,7 @@ BUILD_ID="$(date '+%s')"
 if [ -d "$PWD/.git" ]
 then
   # Set git commit id and name for later use
-  COMMIT_ID="$(git -C "$PWD/.git" log -n 1 --oneline | cut -d ' ' -f 1)"
+  COMMIT_ID="$(git -C "$PWD/.git" rev-parse --short HEAD)"
   # Strip branch paths and any slashes so version string is clean
   BRANCH_NAME="$(git -C "$PWD/.git" symbolic-ref HEAD | sed 's|.*heads/||')"
 


### PR DESCRIPTION
This update uses rev-parse to obtain the current commit id, rather than attempting to get the most recent single line log entry and trimming the commit id out of it, given that, in some cases such as when git is configured to show GPG signatures, this will result in multiple lines.

Fixes #6