### PR TITLE
Ignore quilt exit code 2

### DIFF
--- a/src/container/debcraft-builder.sh
+++ b/src/container/debcraft-builder.sh
@@ -45,7 +45,9 @@ else
   then
     log_info "Apply patches with Quilt"
     export QUILT_PATCHES=debian/patches
-    quilt push -a
+    # If all patches have already been applied, attempting to push any more results
+    # in an exit status of 2.  As this is not an error, it should be ignored.
+    quilt push -a || [ $? -eq 2 ]
   fi
 fi
 

--- a/src/container/debcraft-tester.sh
+++ b/src/container/debcraft-tester.sh
@@ -25,7 +25,9 @@ if [ -f debian/patches/series ]
 then
   log_info "Apply patches with Quilt"
   export QUILT_PATCHES=debian/patches
-  quilt push -a
+    # If all patches have already been applied, attempting to push any more results
+    # in an exit status of 2.  As this is not an error, it should be ignored.
+    quilt push -a || [ $? -eq 2 ]
 fi
 
 


### PR DESCRIPTION
Whenever quilt attempts to apply or remove patches, and there are no patches to apply or remove due to being at the top or bottom of the stack, quilt give an exit status of 2.  However, `set -e` in a bash script causes the entire script to stop when it encounters any exit status other than 0.  Thus, the exit status of 2 needs to be ignored explicitly.

Fixes #10